### PR TITLE
Remove exception prints

### DIFF
--- a/pynrfjprog/MultiAPI.py
+++ b/pynrfjprog/MultiAPI.py
@@ -135,7 +135,6 @@ class MultiAPI(object):
                 raise TimeoutError("CmdQueue is full and was not cleared in 10 seconds!")
 
         if ack.exception is not None:
-            print(ack.stacktrace)
             raise ack.exception
         if ack.result is not None:
             return ack.result

--- a/pynrfjprog/__init__.py
+++ b/pynrfjprog/__init__.py
@@ -3,4 +3,4 @@ Package marker file.
 
 """
 
-__version__ = "9.7.3"
+__version__ = "9.7.3-dev1"

--- a/pynrfjprog/__init__.py
+++ b/pynrfjprog/__init__.py
@@ -3,4 +3,4 @@ Package marker file.
 
 """
 
-__version__ = "9.7.3-dev1"
+__version__ = "9.7.4"

--- a/sca_pipeline.groovy
+++ b/sca_pipeline.groovy
@@ -6,15 +6,14 @@
 // service to your git repository.
 // During the first launch, you have to enter ALTERNATIVE_VERSION parameter.
 
-
-@Library('JenkinsMain@2.16.15')_
+@Library('JenkinsMain@2.16.36')_
 
 
 pipelinePythonSCA(
     baseBranch: "fix_problem_with_concurrent_access_via_multiapi",
     agentLabel: "pylint",
     pythonVersion: '3.6',
-    installFromSetup: true,
+    packages: ["."],
     runPipCheck: true,
     runUnitTests: false,
 )


### PR DESCRIPTION
This PR removes the exception prints that occurs even if we suppress the exception:
```
Captured stdout:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/pynrfjprog/MultiAPI.py", line 160, in _runner
    res = api_functions[cmd.cmd](*cmd.args, **cmd.kwargs)
  File "/usr/local/lib/python3.6/site-packages/pynrfjprog/API.py", line 1218, in rtt_read
    raise APIError(result)
pynrfjprog.API.APIError: An error was reported by NRFJPROG DLL: -102 JLINKARM_DLL_ERROR.
```